### PR TITLE
feat: permit async startup

### DIFF
--- a/src/test/java/org/eclipse/dataplane/ControlPlane.java
+++ b/src/test/java/org/eclipse/dataplane/ControlPlane.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static jakarta.ws.rs.core.MediaType.WILDCARD;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * This simulates control plane for both consumer and provider.
@@ -102,7 +103,14 @@ public class ControlPlane {
         @Path("/{transferId}/dataflow/prepared")
         @Consumes(WILDCARD)
         public void prepared(@PathParam("transferId") String transferId, DataFlowResponseMessage message) {
+            assertThat(message.state()).isEqualTo("PREPARED");
+        }
 
+        @POST
+        @Path("/{transferId}/dataflow/started")
+        @Consumes(WILDCARD)
+        public void started(@PathParam("transferId") String transferId, DataFlowResponseMessage message) {
+            assertThat(message.state()).isEqualTo("STARTED");
         }
 
         @POST


### PR DESCRIPTION
### What
Permits async startup

### Notes
I added json serdes for in memory storage to decouple stored flows from the loaded in memory, (otherwise every change to a dataflow will be already stored without actually calling `save`)

Closes #23 