### PR TITLE
chore: use correct scm connection

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,7 +71,7 @@ mavenPublishing {
         }
         scm {
             url.set("https://github.com/eclipse-dataplane-core/dataplane-sdk-java")
-            connection.set("scm:git:git@github.com:eclipse-dataplane-core/dataplane-sdk-go.git")
+            connection.set("scm:git:git@github.com:eclipse-dataplane-core/dataplane-sdk-java.git")
         }
     }
 }


### PR DESCRIPTION
For Maven publications, the scm connection currently points to the `go` SDK. Updates it to point to this repository.