### PR TITLE
fix: group and version config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,10 +7,10 @@ plugins {
     id("com.vanniktech.maven.publish") version "0.36.0"
 }
 
-group = "org.eclipse.dataplane-core"
-version = "0.0.12-SNAPSHOT"
-
 subprojects {
+    group = "org.eclipse.dataplane-core"
+    version = "0.0.12-SNAPSHOT"
+
     apply(plugin = "signing")
     apply(plugin = "maven-publish")
     apply(plugin = "com.vanniktech.maven.publish")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,9 +8,6 @@ plugins {
 }
 
 subprojects {
-    group = "org.eclipse.dataplane-core"
-    version = "0.0.12-SNAPSHOT"
-
     apply(plugin = "signing")
     apply(plugin = "maven-publish")
     apply(plugin = "com.vanniktech.maven.publish")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+group=org.eclipse.dataplane-core
+version=0.0.12-SNAPSHOT


### PR DESCRIPTION
Moves configuration of `group` and `version` to the subprojects block, as I missed this during refactoring. Currently, publishing is broken, as the group is set to the directory path (as seen [here](https://github.com/eclipse-dataplane-core/dataplane-sdk-java/actions/runs/27202360448/job/80309278095)).