### PR TITLE
fix: use correct control plane endpoint for registration

### DIFF
--- a/dataplane-sdk-core/src/main/java/org/eclipse/dataplane/Dataplane.java
+++ b/dataplane-sdk-core/src/main/java/org/eclipse/dataplane/Dataplane.java
@@ -329,9 +329,9 @@ public class Dataplane {
 
         return toJson(message)
                 .map(body -> HttpRequest.newBuilder()
-                        .uri(URI.create(controlPlaneEndpoint + "/dataplanes/register"))
+                        .uri(URI.create(controlPlaneEndpoint + "/dataplanes"))
                         .header("content-type", "application/json")
-                        .POST(HttpRequest.BodyPublishers.ofString(body))
+                        .PUT(HttpRequest.BodyPublishers.ofString(body))
                         .build()
                 )
                 .compose(request -> {

--- a/e2e-tests/src/test/java/org/eclipse/dataplane/DataplaneTest.java
+++ b/e2e-tests/src/test/java/org/eclipse/dataplane/DataplaneTest.java
@@ -38,6 +38,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -154,7 +156,7 @@ class DataplaneTest {
 
         @Test
         void shouldRegisterOnTheControlPlane() {
-            controlPlane.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200)));
+            controlPlane.stubFor(put(anyUrl()).willReturn(aResponse().withStatus(200)));
 
             var dataplane = Dataplane.newInstance()
                     .id("dataplane-id")
@@ -166,7 +168,7 @@ class DataplaneTest {
             var result = dataplane.registerOn(controlPlane.baseUrl());
 
             assertThat(result.succeeded()).isTrue();
-            controlPlane.verify(postRequestedFor(urlPathEqualTo("/dataplanes/register"))
+            controlPlane.verify(putRequestedFor(urlPathEqualTo("/dataplanes"))
                     .withRequestBody(and(
                             matchingJsonPath("endpoint", equalTo("http://localhost/dataplane")),
                             matchingJsonPath("transferTypes[0]", equalTo("SupportedTransferType-PUSH")),


### PR DESCRIPTION
Updates the method for registering a control plane. The dataplane now makes a `PUT` request to `/dataplanes` to match the endpoint defined in the specification.

Closes #101 